### PR TITLE
🐛 fix: Solver, Critic prompt {context} 관련 버그 해결

### DIFF
--- a/src/agent/nodes/critic.py
+++ b/src/agent/nodes/critic.py
@@ -11,16 +11,26 @@ from src.utils.text import extract_json_from_text
 class CriticNode(BaseLLMNode):
     def __init__(self, config):
         super().__init__(config, model_name="main_solver")
-        self.user_prompt_template = config.prompt.critic.user
-        self.system_prompt = config.prompt.critic.system
+        self.cfg = config
         self.enable_thinking = config.prompt.critic.strategy.get(
             "enable_thinking", False
         )
 
     @traceable(name="CriticNode")
     def __call__(self, state: AgentState) -> Dict[str, List[CriticResult]]:
-        # State에서 필요한 모든 정보 추출
-        problem = state.get("problem", {})
+        
+        track_info = state.get("track_info", {})
+        is_rag_required = track_info.get("is_rag_required", False)
+
+        context_str = ""
+        track = ""
+        if is_rag_required:
+            for i, document in enumerate(state["retrieval_results"]):
+                context_str += f"[context_{i+1}: {document['title']}]\n{document['body']}\n\n"
+            track = "track_b"
+        else:
+            track = "track_a"
+
         solver_results = state["solver_results"]
 
         critic_results = []
@@ -28,19 +38,21 @@ class CriticNode(BaseLLMNode):
         # 각 결과에 대한 평가 진행
         for i, solver_result in enumerate(solver_results):
 
-            choices_str = ", ".join(
-                [f"{i+1}. {c}" for i, c in enumerate(state["problem"].choices)]
-            )
+            payload = {
+                "user_prompt": self.cfg.prompt.critic[track].user,
+                "system_prompt": self.cfg.prompt.critic[track].system,
+                "paragraph": state["problem"].paragraph,
+                "question": state["problem"].question,
+                "choices": solver_result["raw_choice"],
+                "predicted_answer": solver_result["raw_answer"],
+                "reasoning": solver_result["reasoning"],
+            }
+            if track == "track_b":
+                payload["context"] = context_str
 
             # 템플릿에 따른 모델 추론 진행
             raw_output = self.generate(
-                self.user_prompt_template,
-                system_prompt=self.system_prompt,
-                paragraph=state["problem"].paragraph,
-                question=state["problem"].question,
-                choices=choices_str,
-                predicted_answer=solver_result["answer"],
-                reasoning=solver_result["reasoning"],
+                **payload
             )
 
             # raw 결과 json으로 전처리

--- a/src/agent/nodes/solver.py
+++ b/src/agent/nodes/solver.py
@@ -39,10 +39,15 @@ class SolverNode(BaseLLMNode):
 
         track_info = state.get("track_info", {})
         is_rag_required = track_info.get("is_rag_required", False)
-        track = "track_b" if is_rag_required else "track_a"
 
-        retrieved_context = state.get("retrieved_context", [])
-        context = "\n".join(retrieved_context) if retrieved_context else ""
+        context_str = ""
+        track = ""
+        if is_rag_required:
+            for i, document in enumerate(state["retrieval_results"]):
+                context_str += f"[context_{i+1}: {document['title']}]\n{document['body']}\n\n"
+            track = "track_b"
+        else:
+            track = "track_a"
 
         tta_versions = self._generate_tta_versions(state["problem"].choices)
         solver_results = []
@@ -57,7 +62,7 @@ class SolverNode(BaseLLMNode):
                 "choices": choices_str,
             }
             if track == "track_b":
-                input_kwargs["context"] = context
+                input_kwargs["context"] = context_str
 
             raw_output = self.generate(
                 user_prompt=self.user_prompt_template[track],
@@ -67,6 +72,8 @@ class SolverNode(BaseLLMNode):
             )
 
             parsed_result = self._parse_and_remap(raw_output, original_indices)
+
+            parsed_result["raw_choice"] = choices_str
 
             solver_results.append(parsed_result)
 
@@ -103,7 +110,6 @@ class SolverNode(BaseLLMNode):
 
             # 섞인 순서대로 선지 재배열
             shuffled_choices = [choices[i - 1] for i in shuffled_indices]
-
             versions.append((shuffled_choices, shuffled_indices))
 
         return versions
@@ -131,6 +137,7 @@ class SolverNode(BaseLLMNode):
             return {
                 "reasoning": data.get("think", data.get("reasoning", "")).strip(),
                 "answer": original_answer,
+                "raw_answer": shuffled_idx,
             }
         except Exception:
             return {"reasoning": "Parsing failed", "answer": 0}

--- a/src/agent/state.py
+++ b/src/agent/state.py
@@ -13,6 +13,8 @@ class PromptResult(TypedDict):
     user_prompt: str
 
 class SolverResult(TypedDict):
+    raw_answer: int
+    raw_choice: str
     answer: int
     reasoning: str
 


### PR DESCRIPTION
## 📝 Summary
Solver node llm 입력에 retriever의 결과가 있지만 retrieved context를 제대로 prompt에 포함하지 못하는 문제가 있었습니다.
Critic node는 retriver result 가 있더라도 critic 입력에 solver 모델이 참조했던 context들이 들어가지 않는 문제가 있었습니다.
이를 해결합니다.
그리고 추론은 tta로 선지 번호가 섞인 채로 추론한 reasoning이 들어가지만 answer에는 원래 선지 번호가 들어가 reasoning에서 말하는 정답 번호와 answer에서 말하는 정답 번호가 달라 critic이 혼란을 겪을 수 있는 문제를 해결하였습니다. 
## 🛠️ Changes
- `src/agent/state.py` SolverResult에 raw_choise, raw_answer 추가.
- solver node와 critic node가 rag가 필요했을 경우 context를 포함하여 generation을 하도록 변경


## ✅ Checklist
- [ ] PR 제목 규칙을 준수했나요?
- [ ] 빌드가 에러 없이 정상적으로 수행되나요?
- [ ] 불필요한 로그나 주석을 제거했나요?
- [ ] 테스트를 완료했나요?

## 🏷️ Issue Tags
- Closed #73 