### PR TITLE
feat: RAG Retrieval 출력 변경 및 함수화 작성 #65

### DIFF
--- a/src/agent/nodes/retrieval.py
+++ b/src/agent/nodes/retrieval.py
@@ -68,7 +68,7 @@ class RetrievalNode:
             limit=self.cfg.model.bge_m3.retriever.top_k,
         )
 
-        retrieval_results:  = []
+        retrieval_results: List[RetrievalResult] = []
         for hit in search_result.points:
             text = hit.payload.get("text", "")
             head, _, body = text.partition("\n\n")

--- a/src/agent/nodes/retrieval.py
+++ b/src/agent/nodes/retrieval.py
@@ -68,16 +68,15 @@ class RetrievalNode:
             limit=self.cfg.model.bge_m3.retriever.top_k,
         )
 
-        retrieval_results: List[RetrievalResult] = []
+        retrieval_results:  = []
         for hit in search_result.points:
-            payload = hit.payload or {}
-            title = payload.get("title", "")
-            body = (
-                payload.get("body")
-                or payload.get("text")
-                or payload.get("content")
-                or ""
+            text = hit.payload.get("text", "")
+            head, _, body = text.partition("\n\n")
+            retrieval_results.append(
+                {
+                    "title": head.replace("문서 제목:", "").strip(),
+                    "body": body.strip(),
+                }
             )
-            retrieval_results.append(RetrievalResult(title=title, body=body))
 
         return {"retrieval_results": retrieval_results}

--- a/src/utils/tools.py
+++ b/src/utils/tools.py
@@ -4,6 +4,17 @@ from langsmith import traceable
 from ddgs import DDGS
 from typing import List, Dict
 
+import os
+import torch
+from typing import Dict, Any, List, cast
+from FlagEmbedding import BGEM3FlagModel
+from qdrant_client import QdrantClient
+from qdrant_client.http import models
+from omegaconf import DictConfig
+from src.agent.state import AgentState, RetrievalResult
+from langsmith import traceable
+
+
 @traceable(name="search_wikipedia")
 def search_wikipedia(query: str) -> str:
     """
@@ -25,6 +36,7 @@ def search_wikipedia(query: str) -> str:
     except Exception as e:
         return f"검색 중 오류 발생: {str(e)}"
 
+
 @traceable(name="duckduckgo_search")
 def duckduckgo_search(query: str) -> List[Dict[str, str]]:
     """
@@ -38,9 +50,69 @@ def duckduckgo_search(query: str) -> List[Dict[str, str]]:
         results = ddgs.text(query, max_results=5)
     formatted_results = []
     for result in results:
-        formatted_results.append({
-            "title": result.get("title", ""),
-            "body": result.get("body", "")
-        })
+        formatted_results.append(
+            {"title": result.get("title", ""), "body": result.get("body", "")}
+        )
     return formatted_results
-    
+
+
+@traceable(name="rag_search")
+def rag_search(cfg: DictConfig, query: str) -> List[Dict[str, str]]:
+    """
+    Args:
+        query (str): 검색할 키워드
+
+    Returns:
+        List[Dict[str, str]]: 검색 결과 리스트 {title: str, body: str}
+    """
+
+    model = BGEM3FlagModel(
+        cfg.model.bge_m3.path,
+        use_fp16=cfg.model.bge_m3.model_kwargs.get("use_fp16", True),
+        device="cpu",
+    )
+    client = QdrantClient("http://localhost:6333")
+    collection_name = "wiki_collection"
+
+    output = model.encode(
+        [query],
+        return_dense=cfg.model.bge_m3.encode_kwargs.return_dense,
+        return_sparse=cfg.model.bge_m3.encode_kwargs.return_sparse,
+    )
+
+    dense_vec = output["dense_vecs"][0].tolist()
+    sparse_vec = output["lexical_weights"][0]
+
+    search_result = client.query_points(
+        collection_name=collection_name,
+        prefetch=[
+            models.Prefetch(
+                query=dense_vec,
+                using="default",
+                limit=cfg.model.bge_m3.retriever.top_k,
+            ),
+            models.Prefetch(
+                query=models.SparseVector(
+                    indices=[int(k) for k in sparse_vec.keys()],
+                    values=list(sparse_vec.values()),
+                ),
+                using="sparse",
+                limit=cfg.model.bge_m3.retriever.top_k,
+            ),
+        ],
+        query=models.FusionQuery(fusion=models.Fusion.RRF),
+        limit=cfg.model.bge_m3.retriever.top_k,
+    )
+
+    formatted_results = []
+    for hit in search_result.points:
+        text = hit.payload.get("text", "")
+        head, _, body = text.partition("\n\n")
+        formatted_results.append(
+            {
+                "title": head.replace("문서 제목:", "").strip(),
+                "body": body.strip(),
+            }
+        )
+
+    return formatted_results


### PR DESCRIPTION
## 📝 Summary

- 기존 retrieval의 결과는 {title, body}형태로 '문서 제목', '본문' 형태로 나오게 되는데, 이를 제대로 나누도록 기능 변경
- Self-retrieval 모듈에서 뽑아낸 키워드를 임베딩하여 RAG 검색이 가능하도록 함수화 진행

## 🛠️ Changes

- retrieval.py에서 return 양식 변경
- tools.py에서 config와 text를 입력으로 검색 결과를 구조화된 출력으로 반환하는 rag_search함수 작성

## ✅ Checklist
- [x] PR 제목 규칙을 준수했나요?
- [x] 빌드가 에러 없이 정상적으로 수행되나요?
- [x] 불필요한 로그나 주석을 제거했나요?
- [x] 테스트를 완료했나요?

## 🏷️ Issue Tags
- Closed #65